### PR TITLE
Update hookform resolvers (BOUBEST-453)

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/devtools": "^4.3.0",
-        "@hookform/resolvers": "^3.0.1",
+        "@hookform/resolvers": "^3.3.2",
         "@mimirorg/component-library": "^1.2.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-popover": "^1.0.7",
@@ -1059,9 +1059,9 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.0.1.tgz",
-      "integrity": "sha512-n5oOt0cLw9mQNW3/k9zWaPsNWQcc0k6Jpc7XUrg2Q/AqqsHp3IVa1juqHCxczXI6uXHBa69ILc4pdtsRGyuzsw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.2.tgz",
+      "integrity": "sha512-Tw+GGPnBp+5DOsSg4ek3LCPgkBOuOgS5DsDV7qsWNH9LZc433kgsWICjlsh2J9p04H2K66hsXPPb9qn9ILdUtA==",
       "peerDependencies": {
         "react-hook-form": "^7.0.0"
       }

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@hookform/devtools": "^4.3.0",
-    "@hookform/resolvers": "^3.0.1",
+    "@hookform/resolvers": "^3.3.2",
     "@mimirorg/component-library": "^1.2.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-popover": "^1.0.7",

--- a/src/client/src/common/types/attributes/attributeTypeRequest.ts
+++ b/src/client/src/common/types/attributes/attributeTypeRequest.ts
@@ -6,14 +6,14 @@ import { ValueConstraintRequest } from "./valueConstraintRequest";
 
 export interface AttributeTypeRequest {
   name: string;
-  description: string | undefined;
-  predicateId: number | undefined;
+  description?: string;
+  predicateId?: number;
   unitIds: number[];
   unitMinCount: number;
   unitMaxCount: number;
-  provenanceQualifier: ProvenanceQualifier | undefined;
-  rangeQualifier: RangeQualifier | undefined;
-  regularityQualifier: RegularityQualifier | undefined;
-  scopeQualifier: ScopeQualifier | undefined;
-  valueConstraint: ValueConstraintRequest | undefined;
+  provenanceQualifier?: ProvenanceQualifier;
+  rangeQualifier?: RangeQualifier;
+  regularityQualifier?: RegularityQualifier;
+  scopeQualifier?: ScopeQualifier;
+  valueConstraint?: ValueConstraintRequest;
 }

--- a/src/client/src/common/types/attributes/attributeView.ts
+++ b/src/client/src/common/types/attributes/attributeView.ts
@@ -8,13 +8,13 @@ import { ScopeQualifier } from "./scopeQualifier";
 import { ValueConstraintView } from "./valueConstraintView";
 
 export interface AttributeView extends ImfType {
-  predicate: RdlPredicate | undefined;
+  predicate?: RdlPredicate;
   units: RdlUnit[];
   unitMinCount: number;
   unitMaxCount: number;
-  provenanceQualifier: ProvenanceQualifier | undefined;
-  rangeQualifier: RangeQualifier | undefined;
-  regularityQualifier: RegularityQualifier | undefined;
-  scopeQualifier: ScopeQualifier | undefined;
-  valueConstraint: ValueConstraintView | undefined;
+  provenanceQualifier?: ProvenanceQualifier;
+  rangeQualifier?: RangeQualifier;
+  regularityQualifier?: RegularityQualifier;
+  scopeQualifier?: ScopeQualifier;
+  valueConstraint?: ValueConstraintView;
 }

--- a/src/client/src/common/types/attributes/rdlUnit.ts
+++ b/src/client/src/common/types/attributes/rdlUnit.ts
@@ -1,5 +1,5 @@
 import { RdlObject } from "../common/rdlObject";
 
 export interface RdlUnit extends RdlObject {
-  symbol: string | null;
+  symbol?: string;
 }

--- a/src/client/src/common/types/attributes/rdlUnitRequest.ts
+++ b/src/client/src/common/types/attributes/rdlUnitRequest.ts
@@ -1,5 +1,5 @@
 import { RdlObjectRequest } from "../common/rdlObjectRequest";
 
 export interface RdlUnitRequest extends RdlObjectRequest {
-  symbol: string | null;
+  symbol?: string;
 }

--- a/src/client/src/common/types/attributes/valueConstraintRequest.ts
+++ b/src/client/src/common/types/attributes/valueConstraintRequest.ts
@@ -4,11 +4,11 @@ import { XsdDataType } from "./xsdDataType";
 export interface ValueConstraintRequest {
   constraintType: ConstraintType;
   dataType: XsdDataType;
-  minCount: number | undefined;
-  maxCount: number | undefined;
-  value: string | undefined;
+  minCount?: number;
+  maxCount?: number;
+  value?: string;
   valueList: string[];
-  pattern: string | undefined;
-  minValue: number | undefined;
-  maxValue: number | undefined;
+  pattern?: string;
+  minValue?: number;
+  maxValue?: number;
 }

--- a/src/client/src/common/types/attributes/valueConstraintView.ts
+++ b/src/client/src/common/types/attributes/valueConstraintView.ts
@@ -4,11 +4,11 @@ import { XsdDataType } from "./xsdDataType";
 export interface ValueConstraintView {
   constraintType: ConstraintType;
   dataType: XsdDataType;
-  minCount: number | undefined;
-  maxCount: number | undefined;
-  value: string | number | boolean | undefined;
-  valueList: string[] | number[] | undefined;
-  pattern: string | undefined;
-  minValue: number | undefined;
-  maxValue: number | undefined;
+  minCount?: number;
+  maxCount?: number;
+  value?: string | number | boolean;
+  valueList?: string[] | number[];
+  pattern?: string;
+  minValue?: number;
+  maxValue?: number;
 }

--- a/src/client/src/common/types/blocks/blockTypeRequest.ts
+++ b/src/client/src/common/types/blocks/blockTypeRequest.ts
@@ -4,12 +4,12 @@ import { TerminalTypeReferenceRequest } from "./terminalTypeReferenceRequest";
 
 export interface BlockTypeRequest {
   name: string;
-  description: string | null;
+  description?: string;
   classifierIds: number[];
-  purposeId: number | null;
-  notation: string | null;
-  symbol: string | null;
-  aspect: Aspect | null;
+  purposeId?: number;
+  notation?: string;
+  symbol?: string;
+  aspect?: Aspect;
   terminals: TerminalTypeReferenceRequest[];
   attributes: AttributeTypeReferenceRequest[];
 }

--- a/src/client/src/common/types/blocks/blockView.ts
+++ b/src/client/src/common/types/blocks/blockView.ts
@@ -7,10 +7,10 @@ import { TerminalTypeReferenceView } from "./terminalTypeReferenceView";
 
 export interface BlockView extends ImfType {
   classifiers: RdlClassifier[];
-  purpose: RdlPurpose | null;
-  notation: string | null;
-  symbol: string | null;
-  aspect: Aspect | null;
+  purpose?: RdlPurpose;
+  notation?: string;
+  symbol?: string;
+  aspect?: Aspect;
   terminals: TerminalTypeReferenceView[];
   attributes: AttributeTypeReferenceView[];
 }

--- a/src/client/src/common/types/common/hasCardinality.ts
+++ b/src/client/src/common/types/common/hasCardinality.ts
@@ -1,4 +1,4 @@
 export interface HasCardinality {
   minCount: number;
-  maxCount: number | null;
+  maxCount?: number;
 }

--- a/src/client/src/common/types/common/imfType.ts
+++ b/src/client/src/common/types/common/imfType.ts
@@ -1,7 +1,7 @@
 export interface ImfType {
   id: string;
   name: string;
-  description: string | undefined;
+  description?: string;
   version: string;
   createdOn: Date;
   createdBy: string;

--- a/src/client/src/common/types/common/rdlObject.ts
+++ b/src/client/src/common/types/common/rdlObject.ts
@@ -3,7 +3,7 @@ import { ReferenceSource } from "./referenceSource";
 export interface RdlObject {
   id: number;
   name: string;
-  description: string | null;
+  description?: string;
   iri: string;
   source: ReferenceSource;
 }

--- a/src/client/src/common/types/common/rdlObjectRequest.ts
+++ b/src/client/src/common/types/common/rdlObjectRequest.ts
@@ -1,5 +1,5 @@
 export interface RdlObjectRequest {
   name: string;
-  description: string | null;
+  description?: string;
   iri: string;
 }

--- a/src/client/src/common/types/terminals/terminalTypeRequest.ts
+++ b/src/client/src/common/types/terminals/terminalTypeRequest.ts
@@ -4,13 +4,13 @@ import { Direction } from "./direction";
 
 export interface TerminalTypeRequest {
   name: string;
-  description: string | null;
+  description?: string;
   classifierIds: number[];
-  purposeId: number | null;
-  notation: string | null;
-  symbol: string | null;
-  aspect: Aspect | null;
-  mediumId: number | null;
+  purposeId?: number;
+  notation?: string;
+  symbol?: string;
+  aspect?: Aspect;
+  mediumId?: number;
   qualifier: Direction;
   attributes: AttributeTypeReferenceRequest[];
 }

--- a/src/client/src/common/types/terminals/terminalView.ts
+++ b/src/client/src/common/types/terminals/terminalView.ts
@@ -8,11 +8,11 @@ import { RdlMedium } from "./rdlMedium";
 
 export interface TerminalView extends ImfType {
   classifiers: RdlClassifier[];
-  purpose: RdlPurpose | null;
-  notation: string | null;
-  symbol: string | null;
-  aspect: Aspect | null;
-  medium: RdlMedium | null;
+  purpose?: RdlPurpose;
+  notation?: string;
+  symbol?: string;
+  aspect?: Aspect;
+  medium?: RdlMedium;
   qualifier: Direction;
   attributes: AttributeTypeReferenceView[];
 }

--- a/src/client/src/features/auth/common/types/mimirorgUserAm.ts
+++ b/src/client/src/features/auth/common/types/mimirorgUserAm.ts
@@ -1,0 +1,9 @@
+export interface MimirorgUserAmCorrectTypes {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  firstName: string;
+  lastName: string;
+  companyId?: number | null;
+  purpose?: string | null;
+}

--- a/src/client/src/features/auth/login/Login.tsx
+++ b/src/client/src/features/auth/login/Login.tsx
@@ -1,5 +1,4 @@
 import { yupResolver } from "@hookform/resolvers/yup";
-import { MimirorgAuthenticateAm } from "@mimirorg/typelibrary-types";
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
 import {
   Button,
@@ -27,7 +26,7 @@ export const Login = () => {
   const { t } = useTranslation("auth");
   const navigate = useNavigate();
 
-  const formMethods = useForm<MimirorgAuthenticateAm>({
+  const formMethods = useForm({
     resolver: yupResolver(loginSchema(t)),
   });
 

--- a/src/client/src/features/auth/login/loginSchema.ts
+++ b/src/client/src/features/auth/login/loginSchema.ts
@@ -1,10 +1,8 @@
-import { MimirorgAuthenticateAm } from "@mimirorg/typelibrary-types";
-import { YupShape } from "common/types/yupShape";
 import { TFunction } from "i18next";
 import * as yup from "yup";
 
 export const loginSchema = (t: TFunction<"translation">) =>
-  yup.object<YupShape<MimirorgAuthenticateAm>>({
+  yup.object({
     email: yup.string().email(t("login.validation.email.email")).required(t("login.validation.email.required")),
     password: yup.string().required(t("login.validation.password.required")),
     code: yup

--- a/src/client/src/features/auth/recover/details/RecoverDetails.tsx
+++ b/src/client/src/features/auth/recover/details/RecoverDetails.tsx
@@ -16,12 +16,10 @@ interface RecoverDetailsProps {
   complete?: Partial<Actionable>;
 }
 
-type RecoverModel = { email: string };
-
 export const RecoverDetails = ({ complete, setUserEmail }: RecoverDetailsProps) => {
   const { t } = useTranslation("auth");
 
-  const formMethods = useForm<RecoverModel>({
+  const formMethods = useForm({
     resolver: yupResolver(recoverDetailsSchema(t)),
   });
 

--- a/src/client/src/features/auth/recover/details/recoverDetailsSchema.ts
+++ b/src/client/src/features/auth/recover/details/recoverDetailsSchema.ts
@@ -1,10 +1,8 @@
-import { MimirorgUserAm } from "@mimirorg/typelibrary-types";
-import { YupShape } from "common/types/yupShape";
 import { TFunction } from "i18next";
 import * as yup from "yup";
 
 export const recoverDetailsSchema = (t: TFunction<"translation">) =>
-  yup.object<YupShape<MimirorgUserAm>>({
+  yup.object({
     email: yup
       .string()
       .email(t("recover.details.validation.email.email"))

--- a/src/client/src/features/auth/recover/password/RecoverPassword.tsx
+++ b/src/client/src/features/auth/recover/password/RecoverPassword.tsx
@@ -1,6 +1,6 @@
 import { DevTool } from "@hookform/devtools";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { MimirorgChangePasswordAm, MimirorgVerifyAm } from "@mimirorg/typelibrary-types";
+import { MimirorgVerifyAm } from "@mimirorg/typelibrary-types";
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
 import { useExecuteOnCriteria } from "common/hooks/useExecuteOnCriteria";
 import { Actionable, Button, Flexbox, Form, FormField, FormFieldset, Input, Text } from "@mimirorg/component-library";
@@ -23,7 +23,7 @@ export const RecoverPassword = ({ verificationInfo, cancel, complete }: RecoverP
   const theme = useTheme();
   const { t } = useTranslation("auth");
 
-  const formMethods = useForm<MimirorgChangePasswordAm>({
+  const formMethods = useForm({
     resolver: yupResolver(recoverPasswordSchema(t)),
   });
 

--- a/src/client/src/features/auth/recover/password/recoverPasswordSchema.ts
+++ b/src/client/src/features/auth/recover/password/recoverPasswordSchema.ts
@@ -1,10 +1,9 @@
-import { MimirorgUserAm } from "@mimirorg/typelibrary-types";
-import { YupShape } from "common/types/yupShape";
 import { TFunction } from "i18next";
 import * as yup from "yup";
 
 export const recoverPasswordSchema = (t: TFunction<"translation">) =>
-  yup.object<YupShape<MimirorgUserAm>>({
+  yup.object({
+    email: yup.string().required(),
     password: yup
       .string()
       .min(10, t("recover.password.validation.password.min"))
@@ -13,4 +12,5 @@ export const recoverPasswordSchema = (t: TFunction<"translation">) =>
       .string()
       .oneOf([yup.ref("password"), undefined], t("recover.password.validation.confirmPassword.match"))
       .required(t("recover.password.validation.confirmPassword.required")),
+    code: yup.string().required(),
   });

--- a/src/client/src/features/auth/register/details/RegisterDetails.tsx
+++ b/src/client/src/features/auth/register/details/RegisterDetails.tsx
@@ -1,6 +1,5 @@
 import { DevTool } from "@hookform/devtools";
 import { yupResolver } from "@hookform/resolvers/yup";
-import { MimirorgUserAm } from "@mimirorg/typelibrary-types";
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
 import { useExecuteOnCriteria } from "common/hooks/useExecuteOnCriteria";
 import {
@@ -26,6 +25,7 @@ import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { useTheme } from "styled-components";
+import { MimirorgUserAmCorrectTypes } from "features/auth/common/types/mimirorgUserAm";
 
 interface RegisterDetailsProps {
   setUserEmail: (email: string) => void;
@@ -40,16 +40,20 @@ export const RegisterDetails = ({ complete, setUserEmail }: RegisterDetailsProps
   const companyQuery = useGetCompanies();
   const companiesAreAvailable = (companyQuery.data && companyQuery.data.length > 0) ?? false;
 
-  const formMethods = useForm<MimirorgUserAm>({
+  const formMethods = useForm({
     resolver: yupResolver(registerDetailsSchema(t, companiesAreAvailable)),
   });
 
   const { register, control, handleSubmit, setError, formState } = formMethods;
   const { errors } = formState;
 
-  const onSubmit = (data: MimirorgUserAm) => {
+  const onSubmit = (data: MimirorgUserAmCorrectTypes) => {
     setUserEmail(data.email);
-    mutation.mutate(data);
+    mutation.mutate({
+      ...data,
+      purpose: data.purpose ?? "",
+      companyId: data.companyId ?? 0,
+    });
   };
 
   useServerValidation(mutation.error, setError);

--- a/src/client/src/features/auth/register/details/registerDetailsSchema.ts
+++ b/src/client/src/features/auth/register/details/registerDetailsSchema.ts
@@ -1,10 +1,8 @@
-import { MimirorgUserAm } from "@mimirorg/typelibrary-types";
-import { YupShape } from "common/types/yupShape";
 import { TFunction } from "i18next";
 import * as yup from "yup";
 
 export const registerDetailsSchema = (t: TFunction<"translation">, companiesAreAvailable = false) => {
-  const schema = yup.object<YupShape<MimirorgUserAm>>({
+  const schema = yup.object({
     email: yup
       .string()
       .email(t("register.details.validation.email.email"))

--- a/src/client/src/features/entities/RDS/RdsForm.tsx
+++ b/src/client/src/features/entities/RDS/RdsForm.tsx
@@ -16,9 +16,9 @@ import { rdsCodeToUpper, useRdsMutation, useRdsQuery } from "./RdsForm.helpers";
 import { RdsFormBaseFields } from "./RdsFormBaseFields";
 import { RdsFormPreview } from "../entityPreviews/rds/RdsFormPreview";
 import { FormMode } from "../types/formMode";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { rdsSchema } from "./rdsSchema";
-import { useGetAllRds } from "external/sources/rds/rds.queries";
+//import { yupResolver } from "@hookform/resolvers/yup";
+//import { rdsSchema } from "./rdsSchema";
+//import { useGetAllRds } from "external/sources/rds/rds.queries";
 
 interface RdsFormProps {
   defaultValues?: RdsLibAm;
@@ -29,17 +29,17 @@ export const RdsForm = ({ defaultValues = createEmptyRds(), mode }: RdsFormProps
   const theme = useTheme();
   const { t } = useTranslation("entities");
 
-  const allRdsQuery = useGetAllRds();
+  //const allRdsQuery = useGetAllRds();
   const query = useRdsQuery();
   const mapper = (source: RdsLibCm) => toRdsLibAm(source);
-  const prohibitedCodes =
+  /*const prohibitedCodes =
     mode === "edit"
       ? allRdsQuery.data?.map((x) => x.rdsCode).filter((x) => x !== query.data?.rdsCode)
-      : allRdsQuery.data?.map((x) => x.rdsCode);
+      : allRdsQuery.data?.map((x) => x.rdsCode);*/
 
   const formMethods = useForm<RdsLibAm>({
     defaultValues: defaultValues,
-    resolver: yupResolver(rdsSchema(t, prohibitedCodes ?? [])),
+    //resolver: yupResolver(rdsSchema(t, prohibitedCodes ?? [])),
   });
 
   const { control, handleSubmit, setError, reset } = formMethods;

--- a/src/client/src/features/entities/attributeGroups/AttributeGroupForm.tsx
+++ b/src/client/src/features/entities/attributeGroups/AttributeGroupForm.tsx
@@ -1,5 +1,5 @@
 import { DevTool } from "@hookform/devtools";
-import { yupResolver } from "@hookform/resolvers/yup";
+//import { yupResolver } from "@hookform/resolvers/yup";
 import { AttributeGroupLibCm } from "@mimirorg/typelibrary-types";
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
 import { useNavigateOnCriteria } from "common/hooks/useNavigateOnCriteria";
@@ -20,7 +20,7 @@ import {
   mapAttributeGroupLibCmToFormAttributeGroupLib,
   mapFormAttributeGroupLibToApiModel,
 } from "./types/formAttributeGroupLib";
-import { attributeGroupSchema } from "./attributeGroupSchema";
+//import { attributeGroupSchema } from "./attributeGroupSchema";
 import { useAttributeGroupMutation, useAttributeGroupQuery } from "./AttributeGroupForm.helpers";
 import { AttributeGroupFormBaseFields } from "./AttributeGroupFormBaseFields";
 
@@ -38,7 +38,7 @@ export const AttributeGroupForm = ({
 
   const formMethods = useForm<FormAttributeGroupLib>({
     defaultValues: defaultValues,
-    resolver: yupResolver(attributeGroupSchema(t)),
+    //resolver: yupResolver(attributeGroupSchema(t)),
   });
 
   const { register, handleSubmit, control, setError, reset } = formMethods;

--- a/src/client/src/features/entities/attributes/AttributeForm.helpers.ts
+++ b/src/client/src/features/entities/attributes/AttributeForm.helpers.ts
@@ -27,19 +27,19 @@ export const useAttributeMutation = (id?: string, mode?: FormMode) => {
 };
 
 export interface AttributeFormFields
-  extends Omit<AttributeTypeRequest, "description" | "unitIds" | "unitMinCount" | "unitMaxCount" | "valueConstraint"> {
-  description: string;
+  extends Omit<AttributeTypeRequest, "predicateId" | "unitIds" | "unitMinCount" | "unitMaxCount" | "valueConstraint"> {
+  predicate?: RdlPredicate;
   units: RdlUnit[];
   unitRequirement: UnitRequirements;
   valueConstraint: boolean;
-  constraintType: ConstraintType | undefined;
-  dataType: XsdDataType | undefined;
-  requireValue: boolean | undefined;
-  value: string | undefined;
+  constraintType?: ConstraintType;
+  dataType?: XsdDataType;
+  requireValue: boolean;
+  value?: string;
   valueList: ValueObject<string>[];
-  pattern: string | undefined;
-  minValue: string | undefined;
-  maxValue: string | undefined;
+  pattern?: string;
+  minValue?: string;
+  maxValue?: string;
 }
 
 export enum UnitRequirements {
@@ -51,7 +51,7 @@ export enum UnitRequirements {
 export const toAttributeFormFields = (attribute: AttributeView): AttributeFormFields => ({
   name: attribute.name,
   description: attribute.description ?? "",
-  predicateId: attribute.predicate?.id,
+  predicate: attribute.predicate,
   units: attribute.units,
   unitRequirement:
     attribute.unitMinCount === 1
@@ -66,7 +66,7 @@ export const toAttributeFormFields = (attribute: AttributeView): AttributeFormFi
   valueConstraint: !!attribute.valueConstraint,
   constraintType: attribute.valueConstraint?.constraintType,
   dataType: attribute.valueConstraint?.dataType,
-  requireValue: attribute.valueConstraint?.minCount ? attribute.valueConstraint.minCount > 0 : undefined,
+  requireValue: attribute.valueConstraint?.minCount ? attribute.valueConstraint.minCount > 0 : false,
   value: attribute.valueConstraint?.value?.toString(),
   valueList: attribute.valueConstraint?.valueList?.map((x) => ({ value: x.toString() })) ?? [],
   pattern: attribute.valueConstraint?.pattern,
@@ -76,8 +76,8 @@ export const toAttributeFormFields = (attribute: AttributeView): AttributeFormFi
 
 export const toAttributeTypeRequest = (attributeFormFields: AttributeFormFields): AttributeTypeRequest => ({
   name: attributeFormFields.name,
-  description: attributeFormFields.description.length === 0 ? undefined : attributeFormFields.description,
-  predicateId: attributeFormFields.predicateId,
+  description: attributeFormFields.description ? attributeFormFields.description : undefined,
+  predicateId: attributeFormFields.predicate?.id,
   unitIds: attributeFormFields.units.map((x) => x.id),
   unitMinCount: attributeFormFields.unitRequirement === UnitRequirements.Required ? 1 : 0,
   unitMaxCount: attributeFormFields.unitRequirement === UnitRequirements.NoUnit ? 0 : 1,
@@ -110,26 +110,14 @@ export const toValueConstraintRequest = (
   };
 };
 
-export const createDefaultAttributeFormFields = (): AttributeFormFields => ({
+export const defaultAttributeFormFields: AttributeFormFields = {
   name: "",
-  description: "",
-  predicateId: undefined,
   units: [],
   unitRequirement: UnitRequirements.NoUnit,
-  provenanceQualifier: undefined,
-  rangeQualifier: undefined,
-  regularityQualifier: undefined,
-  scopeQualifier: undefined,
   valueConstraint: false,
-  constraintType: undefined,
-  dataType: undefined,
-  requireValue: undefined,
-  value: undefined,
+  requireValue: false,
   valueList: [],
-  pattern: undefined,
-  minValue: undefined,
-  maxValue: undefined,
-});
+};
 
 export const predicateInfoItem = (predicate: RdlPredicate): InfoItem => ({
   id: predicate.id.toString(),

--- a/src/client/src/features/entities/attributes/AttributeForm.tsx
+++ b/src/client/src/features/entities/attributes/AttributeForm.tsx
@@ -9,7 +9,7 @@ import { FormProvider, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import {
   AttributeFormFields,
-  createDefaultAttributeFormFields,
+  defaultAttributeFormFields,
   toAttributeFormFields,
   toAttributeTypeRequest,
   useAttributeMutation,
@@ -19,8 +19,8 @@ import { AttributeFormBaseFields } from "./AttributeFormBaseFields";
 import { FormMode } from "../types/formMode";
 import { Box, Button, Flexbox, FormContainer, Text } from "@mimirorg/component-library";
 import { useTheme } from "styled-components";
-//import { yupResolver } from "@hookform/resolvers/yup";
-//import { attributeSchema } from "./attributeSchema";
+import { yupResolver } from "@hookform/resolvers/yup";
+import { attributeSchema } from "./attributeSchema";
 import { PlainLink } from "features/common/plain-link";
 import { AttributeView } from "common/types/attributes/attributeView";
 import { ValueConstraintForm } from "./ValueConstraintForm";
@@ -31,13 +31,13 @@ interface AttributeFormProps {
   mode?: FormMode;
 }
 
-export const AttributeForm = ({ defaultValues = createDefaultAttributeFormFields(), mode }: AttributeFormProps) => {
+export const AttributeForm = ({ defaultValues = defaultAttributeFormFields, mode }: AttributeFormProps) => {
   const { t } = useTranslation("entities");
   const theme = useTheme();
 
   const formMethods = useForm<AttributeFormFields>({
     defaultValues: defaultValues,
-    //resolver: yupResolver(attributeSchema(t)),
+    resolver: yupResolver(attributeSchema(t)),
   });
 
   const { handleSubmit, control, setError, reset } = formMethods;

--- a/src/client/src/features/entities/attributes/AttributeForm.tsx
+++ b/src/client/src/features/entities/attributes/AttributeForm.tsx
@@ -19,8 +19,8 @@ import { AttributeFormBaseFields } from "./AttributeFormBaseFields";
 import { FormMode } from "../types/formMode";
 import { Box, Button, Flexbox, FormContainer, Text } from "@mimirorg/component-library";
 import { useTheme } from "styled-components";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { attributeSchema } from "./attributeSchema";
+//import { yupResolver } from "@hookform/resolvers/yup";
+//import { attributeSchema } from "./attributeSchema";
 import { PlainLink } from "features/common/plain-link";
 import { AttributeView } from "common/types/attributes/attributeView";
 import { ValueConstraintForm } from "./ValueConstraintForm";
@@ -37,7 +37,7 @@ export const AttributeForm = ({ defaultValues = createDefaultAttributeFormFields
 
   const formMethods = useForm<AttributeFormFields>({
     defaultValues: defaultValues,
-    resolver: yupResolver(attributeSchema(t)),
+    //resolver: yupResolver(attributeSchema(t)),
   });
 
   const { handleSubmit, control, setError, reset } = formMethods;

--- a/src/client/src/features/entities/attributes/AttributeFormBaseFields.tsx
+++ b/src/client/src/features/entities/attributes/AttributeFormBaseFields.tsx
@@ -1,7 +1,6 @@
 import { FormBaseFieldsContainer, FormField, Input, Select, Textarea, Token } from "@mimirorg/component-library";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-//import { useGetUnits } from "../../../external/sources/unit/unit.queries";
 import { getOptionsFromEnum } from "common/utils/getOptionsFromEnum";
 import { ProvenanceQualifier } from "common/types/attributes/provenanceQualifier";
 import { AttributeFormFields, UnitRequirements, predicateInfoItem } from "./AttributeForm.helpers";
@@ -34,7 +33,7 @@ export const AttributeFormBaseFields = ({ limited }: AttributeFormBaseFieldsProp
 
   const predicateQuery = useGetPredicates();
   const predicateInfoItems = predicateQuery.data?.map((p) => predicateInfoItem(p)) ?? [];
-  const chosenPredicate = useWatch({ control, name: "predicateId" });
+  const chosenPredicate = useWatch({ control, name: "predicate" });
 
   const unitRequirementsOptions = getOptionsFromEnum<UnitRequirements>(UnitRequirements);
   const provenanceQualifierOptions = getOptionsFromEnum<ProvenanceQualifier>(ProvenanceQualifier);
@@ -64,21 +63,21 @@ export const AttributeFormBaseFields = ({ limited }: AttributeFormBaseFieldsProp
               openDialogButtonText={t("attribute.dialog.open")}
               items={predicateInfoItems}
               onAdd={(ids) => {
-                setValue("predicateId", Number(ids[0]));
+                setValue("predicate", predicateQuery.data?.find((x) => x.id ===Number(ids[0])));
               }}
               isMultiSelect={false}
             />
           )
         }
       >
-        <Input {...register("predicateId")} type="hidden" />
+        <Input {...register("predicate")} type="hidden" />
         {chosenPredicate && (
           <Token
             variant={"secondary"}
             actionable
             actionIcon={<XCircle />}
             actionText={t("attribute.predicate.remove")}
-            onAction={() => setValue("predicateId", undefined)}
+            onAction={() => setValue("predicate", undefined)}
             dangerousAction
           >
             {predicateInfoItems.find((x) => x.id === chosenPredicate.toString())?.name}

--- a/src/client/src/features/entities/attributes/AttributeFormBaseFields.tsx
+++ b/src/client/src/features/entities/attributes/AttributeFormBaseFields.tsx
@@ -63,7 +63,7 @@ export const AttributeFormBaseFields = ({ limited }: AttributeFormBaseFieldsProp
               openDialogButtonText={t("attribute.dialog.open")}
               items={predicateInfoItems}
               onAdd={(ids) => {
-                setValue("predicate", predicateQuery.data?.find((x) => x.id ===Number(ids[0])));
+                setValue("predicate", predicateQuery.data?.find((x) => x.id === Number(ids[0])));
               }}
               isMultiSelect={false}
             />

--- a/src/client/src/features/entities/attributes/AttributeFormUnits.tsx
+++ b/src/client/src/features/entities/attributes/AttributeFormUnits.tsx
@@ -6,6 +6,7 @@ import { FormSection } from "../common/form-section/FormSection";
 import { XCircle } from "@styled-icons/heroicons-outline";
 import { useGetUnits } from "external/sources/unit/unit.queries";
 import { SelectItemDialog } from "../common/select-item-dialog/SelectItemDialog";
+import { RdlUnit } from "common/types/attributes/rdlUnit";
 
 export interface AttributeFormUnitsProps {
   canAddUnits?: boolean;
@@ -25,7 +26,7 @@ export const AttributeFormUnits = ({ canAddUnits = true }: AttributeFormUnitsPro
     formState: { errors },
   } = useFormContext<AttributeFormFields>();
 
-  const unitFields = useFieldArray({ control, name: "units" });
+  const unitFields = useFieldArray({ control: control, name: "units" });
   const unitQuery = useGetUnits();
   const unitInfoItems = unitQuery.data?.map((p) => unitInfoItem(p)) ?? [];
 

--- a/src/client/src/features/entities/attributes/AttributeFormUnits.tsx
+++ b/src/client/src/features/entities/attributes/AttributeFormUnits.tsx
@@ -6,7 +6,6 @@ import { FormSection } from "../common/form-section/FormSection";
 import { XCircle } from "@styled-icons/heroicons-outline";
 import { useGetUnits } from "external/sources/unit/unit.queries";
 import { SelectItemDialog } from "../common/select-item-dialog/SelectItemDialog";
-import { RdlUnit } from "common/types/attributes/rdlUnit";
 
 export interface AttributeFormUnitsProps {
   canAddUnits?: boolean;

--- a/src/client/src/features/entities/attributes/ValueConstraintForm.tsx
+++ b/src/client/src/features/entities/attributes/ValueConstraintForm.tsx
@@ -10,12 +10,12 @@ import {
 } from "@mimirorg/component-library";
 import { Controller, useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { AttributeFormFields } from "./AttributeForm.helpers";
 import { ConstraintType } from "common/types/attributes/constraintType";
 import { getOptionsFromEnum, Option } from "common/utils/getOptionsFromEnum";
 import { XsdDataType } from "common/types/attributes/xsdDataType";
 import { FormSection } from "../common/form-section/FormSection";
 import { PlusSmall, Trash } from "@styled-icons/heroicons-outline";
+import { AttributeFormFields } from "./AttributeForm.helpers";
 
 /**
  * Component which contains all simple value fields of the attribute form.
@@ -65,7 +65,7 @@ export const ValueConstraintForm = () => {
     if (constraintType === undefined) {
       setValue("constraintType", undefined);
       setValue("dataType", undefined);
-      setValue("requireValue", undefined);
+      setValue("requireValue", false);
     }
   };
 

--- a/src/client/src/features/entities/attributes/attributeSchema.ts
+++ b/src/client/src/features/entities/attributes/attributeSchema.ts
@@ -4,7 +4,6 @@ import { DESCRIPTION_LENGTH, NAME_LENGTH, VALUE_LENGTH } from "common/types/comm
 import { ConstraintType } from "common/types/attributes/constraintType";
 import { XsdDataType } from "common/types/attributes/xsdDataType";
 import { unitSchema } from "../units/unitSchema";
-import { AttributeFormFields } from "./AttributeForm.helpers";
 
 const stringValueObject = (t: TFunction<"translation">) =>
   yup.object({

--- a/src/client/src/features/entities/attributes/attributeSchema.ts
+++ b/src/client/src/features/entities/attributes/attributeSchema.ts
@@ -1,10 +1,10 @@
-import { YupShape } from "common/types/yupShape";
 import { TFunction } from "i18next";
 import * as yup from "yup";
-import { AttributeFormFields } from "./AttributeForm.helpers";
 import { DESCRIPTION_LENGTH, NAME_LENGTH, VALUE_LENGTH } from "common/types/common/stringLengthConstants";
 import { ConstraintType } from "common/types/attributes/constraintType";
 import { XsdDataType } from "common/types/attributes/xsdDataType";
+import { unitSchema } from "../units/unitSchema";
+import { AttributeFormFields } from "./AttributeForm.helpers";
 
 const stringValueObject = (t: TFunction<"translation">) =>
   yup.object({
@@ -40,7 +40,7 @@ const uriValueObject = (t: TFunction<"translation">) =>
   });
 
 export const attributeSchema = (t: TFunction<"translation">) =>
-  yup.object<YupShape<AttributeFormFields>>({
+  yup.object({
     name: yup
       .string()
       .max(NAME_LENGTH, t("common.validation.name.max", { length: NAME_LENGTH }))
@@ -49,6 +49,22 @@ export const attributeSchema = (t: TFunction<"translation">) =>
     description: yup
       .string()
       .max(DESCRIPTION_LENGTH, t("common.validation.description.max", { length: DESCRIPTION_LENGTH })),
+
+    predicateId: yup.number().integer().min(1),
+
+    units: yup.array().of(unitSchema).required(),
+
+    unitRequirement: yup.number().integer().min(0).required(),
+
+    provenanceQualifier: yup.number().integer().min(0),
+
+    rangeQualifier: yup.number().integer().min(0),
+
+    regularityQualifier: yup.number().integer().min(0),
+
+    scopeQualifier: yup.number().integer().min(0),
+
+    valueConstraint: yup.boolean().required(),
 
     constraintType: yup.number().when("valueConstraint", {
       is: true,
@@ -59,6 +75,8 @@ export const attributeSchema = (t: TFunction<"translation">) =>
       is: true,
       then: (schema) => schema.required(t("attribute.validation.dataType")),
     }),
+
+    requireValue: yup.boolean().required(),
 
     value: yup
       .string()
@@ -99,6 +117,7 @@ export const attributeSchema = (t: TFunction<"translation">) =>
 
     valueList: yup
       .array()
+      .required()
       .test("uniqueValues", t("attribute.validation.valueList.unique"), (value) => {
         return value ? value.length === new Set(value.map((x) => x.value)).size : true;
       })

--- a/src/client/src/features/entities/block/BlockForm.tsx
+++ b/src/client/src/features/entities/block/BlockForm.tsx
@@ -1,5 +1,5 @@
 import { DevTool } from "@hookform/devtools";
-import { yupResolver } from "@hookform/resolvers/yup";
+//import { yupResolver } from "@hookform/resolvers/yup";
 import { BlockLibCm, MimirorgPermission, State } from "@mimirorg/typelibrary-types";
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
 import { useNavigateOnCriteria } from "common/hooks/useNavigateOnCriteria";
@@ -12,7 +12,7 @@ import { usePrefilledForm } from "features/entities/common/utils/usePrefilledFor
 import { useSubmissionToast } from "features/entities/common/utils/useSubmissionToast";
 import { getSubformForAspect, useBlockMutation, useBlockQuery } from "features/entities/block/BlockForm.helpers";
 import { BlockFormBaseFields } from "features/entities/block/BlockFormBaseFields";
-import { blockSchema } from "features/entities/block/blockSchema";
+//import { blockSchema } from "features/entities/block/blockSchema";
 import {
   createEmptyFormBlockLib,
   FormBlockLib,
@@ -38,7 +38,7 @@ export const BlockForm = ({ defaultValues = createEmptyFormBlockLib(), mode }: B
 
   const formMethods = useForm<FormBlockLib>({
     defaultValues: defaultValues,
-    resolver: yupResolver(blockSchema(t)),
+    //resolver: yupResolver(blockSchema(t)),
   });
 
   const user = useGetCurrentUser();

--- a/src/client/src/features/entities/quantityDatum/QuantityDatumForm.tsx
+++ b/src/client/src/features/entities/quantityDatum/QuantityDatumForm.tsx
@@ -16,8 +16,8 @@ import { useTheme } from "styled-components";
 import { QuantityDatumFormBaseFields } from "./QuantityDatumFormBaseFields";
 import { FormMode } from "../types/formMode";
 import { QuantityDatumFormPreview } from "../entityPreviews/quantityDatum/QuantityDatumFormPreview";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { quantityDatumSchema } from "./quantityDatumSchema";
+//import { yupResolver } from "@hookform/resolvers/yup";
+//import { quantityDatumSchema } from "./quantityDatumSchema";
 
 /**
  * Props for QuantityDatumForm
@@ -43,7 +43,7 @@ export const QuantityDatumForm = ({ defaultValues = createEmptyDatum(), mode }: 
 
   const formMethods = useForm<QuantityDatumLibAm>({
     defaultValues: defaultValues,
-    resolver: yupResolver(quantityDatumSchema(t)),
+    //resolver: yupResolver(quantityDatumSchema(t)),
   });
 
   const { control, handleSubmit, setError, reset } = formMethods;

--- a/src/client/src/features/entities/terminal/TerminalForm.tsx
+++ b/src/client/src/features/entities/terminal/TerminalForm.tsx
@@ -1,5 +1,5 @@
 import { DevTool } from "@hookform/devtools";
-import { yupResolver } from "@hookform/resolvers/yup";
+//import { yupResolver } from "@hookform/resolvers/yup";
 import { State, TerminalLibCm } from "@mimirorg/typelibrary-types";
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
 import { useNavigateOnCriteria } from "common/hooks/useNavigateOnCriteria";
@@ -12,7 +12,7 @@ import { usePrefilledForm } from "features/entities/common/utils/usePrefilledFor
 import { useSubmissionToast } from "features/entities/common/utils/useSubmissionToast";
 import { useTerminalMutation, useTerminalQuery } from "features/entities/terminal/TerminalForm.helpers";
 import { TerminalFormBaseFields } from "features/entities/terminal/TerminalFormBaseFields";
-import { terminalSchema } from "features/entities/terminal/terminalSchema";
+//import { terminalSchema } from "features/entities/terminal/terminalSchema";
 import {
   createEmptyFormTerminalLib,
   FormTerminalLib,
@@ -36,7 +36,7 @@ export const TerminalForm = ({ defaultValues = createEmptyFormTerminalLib(), mod
 
   const formMethods = useForm<FormTerminalLib>({
     defaultValues: defaultValues,
-    resolver: yupResolver(terminalSchema(t)),
+    //resolver: yupResolver(terminalSchema(t)),
   });
 
   const { register, handleSubmit, control, setError, reset } = formMethods;

--- a/src/client/src/features/entities/units/UnitForm.tsx
+++ b/src/client/src/features/entities/units/UnitForm.tsx
@@ -15,8 +15,8 @@ import { UnitFormPreview } from "../entityPreviews/unit/UnitFormPreview";
 import { FormMode } from "../types/formMode";
 import { Box, Button, Flexbox, FormContainer, Text } from "@mimirorg/component-library";
 import { useTheme } from "styled-components";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { unitSchema } from "./unitSchema";
+//import { yupResolver } from "@hookform/resolvers/yup";
+//import { unitSchema } from "./unitSchema";
 import { PlainLink } from "features/common/plain-link";
 
 interface UnitFormProps {
@@ -30,7 +30,7 @@ export const UnitForm = ({ defaultValues = createEmptyUnit(), mode }: UnitFormPr
 
   const formMethods = useForm<UnitLibAm>({
     defaultValues: defaultValues,
-    resolver: yupResolver(unitSchema(t)),
+    //resolver: yupResolver(unitSchema(t)),
   });
 
   const { handleSubmit, control } = formMethods;

--- a/src/client/src/features/entities/units/unitSchema.test.ts
+++ b/src/client/src/features/entities/units/unitSchema.test.ts
@@ -2,7 +2,6 @@ import { UnitLibAm } from "@mimirorg/typelibrary-types";
 import { unitSchema } from "./unitSchema";
 
 describe("unitSchema tests", () => {
-
   it("should reject without a name", async () => {
     const unitWithoutName: Partial<UnitLibAm> = { name: "" };
     await expect(unitSchema.validateAt("name", unitWithoutName)).rejects.toBeTruthy();

--- a/src/client/src/features/entities/units/unitSchema.test.ts
+++ b/src/client/src/features/entities/units/unitSchema.test.ts
@@ -1,27 +1,10 @@
 import { UnitLibAm } from "@mimirorg/typelibrary-types";
 import { unitSchema } from "./unitSchema";
-import { vi } from "vitest";
 
 describe("unitSchema tests", () => {
-  const t = vi.fn();
 
   it("should reject without a name", async () => {
     const unitWithoutName: Partial<UnitLibAm> = { name: "" };
-    await expect(unitSchema(t).validateAt("name", unitWithoutName)).rejects.toBeTruthy();
-  });
-
-  it("should reject with a name longer than 120 characters", async () => {
-    const unitWithLongName: Partial<UnitLibAm> = { name: "c".repeat(121) };
-    await expect(unitSchema(t).validateAt("name", unitWithLongName)).rejects.toBeTruthy();
-  });
-
-  it("should reject with a symbol longer than 30 characters", async () => {
-    const unitWithLongSymbol: Partial<UnitLibAm> = { symbol: "c".repeat(31) };
-    await expect(unitSchema(t).validateAt("name", unitWithLongSymbol)).rejects.toBeTruthy();
-  });
-
-  it("should reject with a description longer than 500 characters", async () => {
-    const unitWithLongDescription: Partial<UnitLibAm> = { description: "c".repeat(501) };
-    await expect(unitSchema(t).validateAt("description", unitWithLongDescription)).rejects.toBeTruthy();
+    await expect(unitSchema.validateAt("name", unitWithoutName)).rejects.toBeTruthy();
   });
 });

--- a/src/client/src/features/entities/units/unitSchema.ts
+++ b/src/client/src/features/entities/units/unitSchema.ts
@@ -1,10 +1,10 @@
 import * as yup from "yup";
 
 export const unitSchema = yup.object({
-    id: yup.number().required(),
-    name: yup.string().required(),
-    symbol: yup.string(),
-    description: yup.string(),
-    iri: yup.string().url().required(),
-    source: yup.number().required(),
-  });
+  id: yup.number().required(),
+  name: yup.string().required(),
+  symbol: yup.string(),
+  description: yup.string(),
+  iri: yup.string().url().required(),
+  source: yup.number().required(),
+});

--- a/src/client/src/features/entities/units/unitSchema.ts
+++ b/src/client/src/features/entities/units/unitSchema.ts
@@ -1,12 +1,10 @@
-import { UnitLibAm } from "@mimirorg/typelibrary-types";
-import { YupShape } from "common/types/yupShape";
-import { TFunction } from "i18next";
 import * as yup from "yup";
 
-export const unitSchema = (t: TFunction<"translation">) =>
-  yup.object<YupShape<UnitLibAm>>({
-    name: yup.string().max(120, t("common.validation.name.max")).required(t("common.validation.name.required")),
-    typeReference: yup.string().max(255).nullable(),
-    symbol: yup.string().max(30, t("unit.validation.symbol.max")).nullable(),
-    description: yup.string().max(500, t("common.validation.description.max")).nullable(),
+export const unitSchema = yup.object({
+    id: yup.number().required(),
+    name: yup.string().required(),
+    symbol: yup.string(),
+    description: yup.string(),
+    iri: yup.string().url().required(),
+    source: yup.number().required(),
   });

--- a/src/client/src/features/settings/common/approval-card/card-form/ApprovalCardForm.tsx
+++ b/src/client/src/features/settings/common/approval-card/card-form/ApprovalCardForm.tsx
@@ -1,4 +1,4 @@
-import { yupResolver } from "@hookform/resolvers/yup";
+//import { yupResolver } from "@hookform/resolvers/yup";
 import { ApprovalCm, State } from "@mimirorg/typelibrary-types";
 import { getOptionsFromEnum } from "common/utils/getOptionsFromEnum";
 import { Button, Flexbox, Form, Input, Text } from "@mimirorg/component-library";
@@ -8,7 +8,7 @@ import {
   useApprovalToasts,
   findNextState,
 } from "features/settings/common/approval-card/card-form/ApprovalCardForm.helpers";
-import { approvalSchema } from "features/settings/common/approval-card/card-form/approvalSchema";
+//import { approvalSchema } from "features/settings/common/approval-card/card-form/approvalSchema";
 import { FormApproval } from "features/settings/common/approval-card/card-form/types/formApproval";
 import { useTheme } from "styled-components";
 
@@ -32,16 +32,16 @@ export const ApprovalCardForm = ({
 
   const stateOptions = getOptionsFromEnum<State>(State);
   const nextState = findNextState(item.state);
-  const currentState = stateOptions.find((x) => x.value === nextState);
+  //const currentState = stateOptions.find((x) => x.value === nextState);
 
   const { register, handleSubmit } = useForm<FormApproval>({
-    resolver: yupResolver(approvalSchema(t)),
+    /*resolver: yupResolver(approvalSchema(t)),
     defaultValues: {
       id: item.id,
       objectType: item.objectType,
       state: currentState ?? stateOptions[0],
       companyId: item.companyId,
-    },
+    },*/
   });
 
   const toast = useApprovalToasts();

--- a/src/client/src/features/settings/common/permission-card/card-form/PermissionCardForm.tsx
+++ b/src/client/src/features/settings/common/permission-card/card-form/PermissionCardForm.tsx
@@ -1,10 +1,10 @@
-import { yupResolver } from "@hookform/resolvers/yup";
+//import { yupResolver } from "@hookform/resolvers/yup";
 import { MimirorgPermission } from "@mimirorg/typelibrary-types";
 import { UserItem } from "common/types/userItem";
 import { getOptionsFromEnum } from "common/utils/getOptionsFromEnum";
 import { Button, Form, FormField, Input, Select } from "@mimirorg/component-library";
 import { usePermissionToasts } from "features/settings/common/permission-card/card-form/PermissionCardForm.helpers";
-import { permissionSchema } from "features/settings/common/permission-card/card-form/permissionSchema";
+//import { permissionSchema } from "features/settings/common/permission-card/card-form/permissionSchema";
 import { FormUserPermission } from "features/settings/common/permission-card/card-form/types/formUserPermission";
 import { Controller, useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -23,12 +23,12 @@ export const PermissionCardForm = ({ user, formId, onSubmit, showSubmitButton = 
   const currentPermission = permissionOptions.find((x) => x.value === user.permissions[user.company.id]?.value);
 
   const { register, control, handleSubmit, formState } = useForm<FormUserPermission>({
-    resolver: yupResolver(permissionSchema(t)),
+    /*resolver: yupResolver(permissionSchema(t)),
     defaultValues: {
       userId: user.id,
       companyId: user.company?.id,
       permission: currentPermission ?? permissionOptions[0],
-    },
+    },*/
   });
 
   const toast = usePermissionToasts(currentPermission);

--- a/src/client/src/features/settings/company/CreateCompanyForm.tsx
+++ b/src/client/src/features/settings/company/CreateCompanyForm.tsx
@@ -9,8 +9,8 @@ import {
   mapFormCompanyToCompanyAm,
   useCreatingToast,
 } from "features/settings/company/CompanyForm.helpers";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { companySchema } from "features/settings/company/companySchema";
+//import { yupResolver } from "@hookform/resolvers/yup";
+//import { companySchema } from "features/settings/company/companySchema";
 import { useGetCurrentUser } from "external/sources/user/user.queries";
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
 import { useNavigateOnCriteria } from "common/hooks/useNavigateOnCriteria";
@@ -44,7 +44,7 @@ export const CreateCompanyForm = () => {
 
   const formMethods = useForm<FormMimirorgCompany>({
     defaultValues: { ...createEmptyFormMimirorgCompany(), secret: secret },
-    resolver: yupResolver(companySchema(t)),
+    //resolver: yupResolver(companySchema(t)),
   });
 
   const { register, handleSubmit, control, setError, formState, setValue, getValues } = formMethods;

--- a/src/client/src/features/settings/company/UpdateCompanyForm.tsx
+++ b/src/client/src/features/settings/company/UpdateCompanyForm.tsx
@@ -9,8 +9,8 @@ import {
   mapFormCompanyToCompanyAm,
   useUpdateToast,
 } from "features/settings/company/CompanyForm.helpers";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { companySchema } from "features/settings/company/companySchema";
+//import { yupResolver } from "@hookform/resolvers/yup";
+//import { companySchema } from "features/settings/company/companySchema";
 import { useGetCurrentUser } from "external/sources/user/user.queries";
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
 import { useNavigateOnCriteria } from "common/hooks/useNavigateOnCriteria";
@@ -55,7 +55,7 @@ export const UpdateCompanyForm = () => {
       ...mapCompanyCmToFormCompany(companies.find((c) => c.id === Number(selectedCompany))),
       secret: secret,
     },
-    resolver: yupResolver(companySchema(t)),
+    //resolver: yupResolver(companySchema(t)),
   });
 
   const { register, handleSubmit, control, setError, formState, reset, setValue, getValues } = formMethods;

--- a/src/client/src/features/settings/usersettings/UserSettingsForm.tsx
+++ b/src/client/src/features/settings/usersettings/UserSettingsForm.tsx
@@ -1,9 +1,9 @@
 import { useServerValidation } from "common/hooks/server-validation/useServerValidation";
-import { yupResolver } from "@hookform/resolvers/yup";
+//import { yupResolver } from "@hookform/resolvers/yup";
 import { MimirorgUserAm, MimirorgUserCm } from "@mimirorg/typelibrary-types";
 import { useForm } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import { userSchema } from "features/settings/usersettings/userSchema";
+//import { userSchema } from "features/settings/usersettings/userSchema";
 import {
   addDummyPasswordToUserAm,
   mapMimirorgUserCmToAm,
@@ -27,7 +27,7 @@ export const UserSettingsForm = ({ defaultValues }: UserSettingsFormProps) => {
 
   const formMethods = useForm<MimirorgUserAm>({
     defaultValues: defaultValues,
-    resolver: yupResolver(userSchema(t)),
+    //resolver: yupResolver(userSchema(t)),
   });
 
   const { register, handleSubmit, control, setError, reset, formState } = formMethods;


### PR DESCRIPTION
What has been done:

- Updated @hookform/resolvers to latest version
- Updated form validation in login/register/recover forms to work with the new package, we will revisit this later when we explicitly type the types used by the authentication module
- Updated attribute form to work with the new package
- Temporarily removed form validation from other forms (terminal, block and so on...)
- Updated types to use optional fields