### PR TITLE
Fix bug where allowDelete returned wrong value (BOUBEST-553)

### DIFF
--- a/src/client/src/components/Search/useButtonFilter.ts
+++ b/src/client/src/components/Search/useButtonFilter.ts
@@ -70,7 +70,7 @@ const allowDelete = (item: ItemType | null, user: UserItem | null): boolean => {
 
   if (item.state === State.Approved) return false;
 
-  if (item.createdBy === user.id) return true;
+  if (item.createdBy === user.id && user.roles.includes("Contributor")) return true;
 
   if (user.roles.filter((x) => x === "Administrator" || x === "Reviewer").length === 0) {
     return false;


### PR DESCRIPTION
The bug occurred when a user is viewing a type that they created, but their role was Reader. In this case, the allowDelete function should return false.